### PR TITLE
Update/google analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,28 +14,6 @@ module.exports = {
   },
   plugins: [
     "gatsby-plugin-styled-components", 
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: "UA-120639061-3", // The property ID; the tracking code won't be generated without it
-        head: true, // Defines where to place the tracking script - `true` in the head and `false` in the body
-        anonymize: true, // Setting this parameter is optional
-        respectDNT: true, // Setting this parameter is also optional
-        // exclude: ["/preview/**", "/do-not-track/me/too/"], // Avoids sending pageview hits from custom paths
-        // pageTransitionDelay: 0, // Delays sending pageview hits on route update (in milliseconds)
-        // optimizeId: "YOUR_GOOGLE_OPTIMIZE_TRACKING_ID", // Enables Google Optimize using your container Id
-        // experimentId: "YOUR_GOOGLE_EXPERIMENT_ID", // Enables Google Optimize Experiment ID
-        // variationId: "YOUR_GOOGLE_OPTIMIZE_VARIATION_ID", // Set Variation ID. 0 for original 1,2,3....
-        // Any additional optional fields
-        // Documented
-        //  here: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#create
-        // and here: https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/
-        // sampleRate: 5, // Specifies what percentage of users should be tracked. This defaults to 100 (no users are sampled out) but large sites may need to use a lower sample rate to stay within Google Analytics processing limits.
-        siteSpeedSampleRate: 10, // This setting determines how often site speed beacons will be sent. By default, 1% of users will be automatically be tracked.
-        cookieDomain: "renci.github.io", // Specifies the domain used to store the analytics cookie. Setting this to 'none' sets the cookie without specifying a domain.
-      },
-
-    }, 
     "gatsby-plugin-image", 
     "gatsby-plugin-react-helmet", 
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,6 +14,12 @@ module.exports = {
   },
   plugins: [
     "gatsby-plugin-styled-components", 
+    {
+      resolve: `gatsby-plugin-google-gtag`,
+      options: {
+        trackingIds: ["G-2G57TL5Z73"],
+      },
+    },
     "gatsby-plugin-image", 
     "gatsby-plugin-react-helmet", 
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "babel-plugin-styled-components": "^2.0.7",
         "gatsby": "^4.20.0",
         "gatsby-plugin-google-analytics": "^4.20.0",
+        "gatsby-plugin-google-gtag": "^4.24.0",
         "gatsby-plugin-image": "^2.20.0",
         "gatsby-plugin-manifest": "^4.20.0",
         "gatsby-plugin-react-helmet": "^5.20.0",
@@ -12817,6 +12818,23 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/gatsby-plugin-google-gtag": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-4.24.0.tgz",
+      "integrity": "sha512-2GHzg727Xr+48kxS5+3xSc246gdQLlAk4L0vn5+KauJsP1aCGb2XpumlUQj8H81TA/BnroBc1wlW4N+k7J4I5Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next",
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0"
       }
     },
     "node_modules/gatsby-plugin-image": {
@@ -35842,6 +35860,15 @@
             "brace-expansion": "^1.1.7"
           }
         }
+      }
+    },
+    "gatsby-plugin-google-gtag": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-4.24.0.tgz",
+      "integrity": "sha512-2GHzg727Xr+48kxS5+3xSc246gdQLlAk4L0vn5+KauJsP1aCGb2XpumlUQj8H81TA/BnroBc1wlW4N+k7J4I5Q==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "minimatch": "^3.1.2"
       }
     },
     "gatsby-plugin-image": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "babel-plugin-styled-components": "^2.0.7",
     "gatsby": "^4.20.0",
-    "gatsby-plugin-google-analytics": "^4.20.0",
+    "gatsby-plugin-google-gtag": "^4.24.0",
     "gatsby-plugin-image": "^2.20.0",
     "gatsby-plugin-manifest": "^4.20.0",
     "gatsby-plugin-react-helmet": "^5.20.0",


### PR DESCRIPTION
Actions summary:
- switched out gatsby plugin packages to updated gtag package (old: `gatsby-plugin-google-analytics`, new: `gatsby-plugin-google-gtag`)
- updated measurement ID with new ID created for GA4 property
- ran the build locally and checked that the request is sending properly